### PR TITLE
[BE] API 명세와 재료 정규화 정리

### DIFF
--- a/app/services/name_mapping.py
+++ b/app/services/name_mapping.py
@@ -68,7 +68,16 @@ _INGREDIENT_ALIASES: dict[str, tuple[str, ...]] = {
         "동태살",
     ),
     "garlic": ("마늘", "다진마늘", "다진 마늘", "통마늘"),
-    "green_onion": ("대파", "파"),
+    "green_onion": (
+        "대파",
+        "파",
+        "leek",
+        "scallion",
+        "spring onion",
+        "spring_onion",
+        "green onion",
+        "green_onion",
+    ),
     "lettuce": ("상추", "양상추", "로메인"),
     "milk": ("우유",),
     "mushroom": (

--- a/docs/api_change_workflow.md
+++ b/docs/api_change_workflow.md
@@ -1,0 +1,49 @@
+# API Change Workflow
+
+FE/AI가 새 기능을 요청하면 공유 API 시트에 먼저 계약을 적고, BE는 그 계약을 기준으로 이슈/브랜치/PR을 만듭니다.
+
+## Rules
+
+- main 직접 push/merge 금지
+- 새 기능/수정은 GitHub issue 먼저 생성
+- branch는 issue 번호를 포함
+- Conventional Commits 사용
+- 기존 FE 응답 필드는 깨지지 않게 additive change 우선
+- breaking change가 필요하면 FE/AI 확인 후 별도 issue로 분리
+- 작업 후 test, commit, push, PR
+
+## Sheet Template
+
+| Field | Example |
+| --- | --- |
+| 기능명 | 추천 카드 즐겨찾기 |
+| 화면/플로우 | 추천 결과 카드에서 저장 버튼 클릭 |
+| Method | `POST` |
+| Path | `/api/v1/recommendations/favorites` |
+| Request | `{ "recipe_name": "돼지고기 대파 소금구이" }` |
+| Response | `{ "status": "success" }` |
+| FE 영향 | 추천 카드 버튼 상태 추가 |
+| AI 영향 | 없음 |
+| 기존 호환성 | 기존 추천 응답 변경 없음 |
+| BE 테스트 | service test, schema validation |
+| Issue | `#00` |
+| PR | `#00` |
+
+## Request Checklist
+
+- FE가 실제로 필요한 화면 상태를 적었는가?
+- request/response 예시가 JSON으로 재현 가능한가?
+- 기존 API를 확장하면 되는지, 새 API가 필요한지 확인했는가?
+- 추천 응답이라면 `ingredient_yes`, `ingredient_no`, `missing_ingredients`, `ingredient_details[].status` 유지 여부를 확인했는가?
+- AI 입력이라면 label key와 정규화 규칙을 확인했는가?
+
+## BE Implementation Checklist
+
+- issue 생성 또는 기존 issue 연결
+- 최신 `origin/main` 기준 branch 생성
+- schema/example/docs 업데이트
+- service/repository 구현
+- 테스트 추가 또는 보강
+- `pytest -q -p no:cacheprovider` 통과
+- PR 본문에 endpoint, 테스트 결과, 호환성 영향만 짧게 작성
+

--- a/docs/api_contract_ai.md
+++ b/docs/api_contract_ai.md
@@ -1,0 +1,124 @@
+# AI API Contract
+
+이 문서는 Jetson/AI 쪽에서 BE로 인식 결과를 전송할 때 지켜야 하는 계약입니다. AI API는 내부 입력용이며, FE 화면에는 SSE와 추천 API를 통해 전달됩니다.
+
+## 공통
+
+- Base URL local: `http://127.0.0.1:8000`
+- Content-Type: `application/json`
+- timestamp: ISO 8601 UTC 권장
+- confidence: `0.0` 이상 `1.0` 이하, 모르면 생략 가능
+- source: 모델 또는 장치/파이프라인 이름
+
+## Ingredient Recognition
+
+### POST `/api/v1/recognitions/ingredients`
+
+AI가 식재료 하나를 감지할 때마다 호출합니다. 이 단계는 바로 inventory DB에 저장하지 않고, FE가 구독 중인 식재료 SSE로만 전달합니다. 사용자가 FE에서 최종 저장하면 `/api/v1/inventory/bulk`가 호출됩니다.
+
+Request:
+
+```json
+{
+  "ingredient_name": "green_onion",
+  "timestamp": "2026-04-27T12:00:00Z",
+  "confidence": 0.93,
+  "source": "ingredient_classifier"
+}
+```
+
+Response:
+
+```json
+{
+  "status": "success",
+  "message": "식재료 인식 이벤트가 발행되었습니다."
+}
+```
+
+Side effect:
+
+- `GET /api/v1/stream/ingredients` 구독자에게 `ingredient_name`, `timestamp` 이벤트 발행
+
+## Ingredient Key Policy
+
+BE 추천 seed core ingredient key는 27개입니다.
+
+```text
+bacon, beef, bread, broccoli, butter, cabbage, carrot, cheese, chicken,
+cucumber, egg, eggplant, fish, garlic, green_onion, lettuce, milk,
+mushroom, onion, pepper, pork, potato, sausage, spinach, tomato,
+yogurt, zucchini
+```
+
+AI label 차이 처리:
+
+- `beef`, `pork`는 AI 추가 예정 클래스이므로 BE seed core ingredient로 사용합니다.
+- `leek`, `scallion`, `spring_onion`은 BE에서 `green_onion`으로 정규화합니다.
+- `ginger`는 AI label에는 있을 수 있지만 추천 seed core ingredient로 사용하지 않습니다.
+- `pepper`는 고추가 아니라 파프리카입니다.
+- `fish`, `mushroom`, `cheese`는 broad key입니다. AI/BE 모두 세부 품종을 확정하지 않습니다.
+
+AI가 보내면 좋은 값:
+
+```text
+green_onion
+beef
+pork
+pepper
+```
+
+전환기 호환 값:
+
+```text
+leek
+scallion
+spring_onion
+spring onion
+```
+
+위 값들은 BE에서 `green_onion`으로 정규화합니다.
+
+## Liquor Recognition
+
+### POST `/api/v1/recognitions/liquor`
+
+AI가 주류를 감지했을 때 호출합니다. BE는 주류 SSE를 먼저 발행하고, 이어 추천 결과를 계산해 추천 SSE를 발행합니다.
+
+Request:
+
+```json
+{
+  "liquor_name": "soju",
+  "timestamp": "2026-04-27T12:00:05Z",
+  "confidence": 0.97,
+  "source": "liquor_classifier"
+}
+```
+
+Response:
+
+```json
+{
+  "status": "success",
+  "message": "주류 인식 이벤트가 발행되었습니다."
+}
+```
+
+Supported liquor keys:
+
+```text
+soju, beer, red_wine, white_wine, sparkling_wine, whisky, sake
+```
+
+Side effects:
+
+- `GET /api/v1/stream/liquor` 구독자에게 주류 이벤트 발행
+- `GET /api/v1/stream/recommendations` 구독자에게 추천 결과 이벤트 발행
+
+## Failure/Retry Guidance
+
+- BE가 4xx를 반환하면 payload key 또는 타입을 확인합니다.
+- 네트워크 실패는 같은 timestamp/source로 재시도해도 됩니다.
+- 동일 프레임에서 같은 label이 반복 감지되면 AI 쪽에서 debounce 후 전송하는 것을 권장합니다.
+

--- a/docs/api_contract_fe.md
+++ b/docs/api_contract_fe.md
@@ -1,0 +1,250 @@
+# FE API Contract
+
+이 문서는 FE 공유 API 시트에 옮기기 위한 BE 계약입니다. 기존 필드는 유지하고, 새 필드는 optional 또는 additive 방식으로만 추가합니다.
+
+## 공통
+
+- Base URL local: `http://127.0.0.1:8000`
+- JSON 날짜/시간: ISO 8601 UTC 문자열
+- 인증: MVP 단계에서는 없음
+- 추천 주류 key: `soju`, `beer`, `red_wine`, `white_wine`, `sparkling_wine`, `whisky`, `sake`
+- 추천 응답 필수 체크리스트 필드: `ingredient_yes`, `ingredient_no`, `missing_ingredients`, `ingredient_details[].status`
+
+## 재료 Key
+
+| key | display |
+| --- | --- |
+| `bacon` | 베이컨 |
+| `beef` | 소고기 |
+| `bread` | 빵 |
+| `broccoli` | 브로콜리 |
+| `butter` | 버터 |
+| `cabbage` | 양배추 |
+| `carrot` | 당근 |
+| `cheese` | 치즈 |
+| `chicken` | 닭고기 |
+| `cucumber` | 오이 |
+| `egg` | 달걀 |
+| `eggplant` | 가지 |
+| `fish` | 생선 |
+| `garlic` | 마늘 |
+| `green_onion` | 대파 |
+| `lettuce` | 상추 |
+| `milk` | 우유 |
+| `mushroom` | 버섯 |
+| `onion` | 양파 |
+| `pepper` | 파프리카 |
+| `pork` | 돼지고기 |
+| `potato` | 감자 |
+| `sausage` | 소시지 |
+| `spinach` | 시금치 |
+| `tomato` | 토마토 |
+| `yogurt` | 요거트 |
+| `zucchini` | 애호박 |
+
+주의:
+
+- `pepper`는 고추가 아니라 파프리카입니다.
+- `leek`, `scallion`, `spring_onion`은 BE에서 `green_onion`으로 정규화합니다.
+- `ginger`는 AI label에는 있을 수 있지만 추천 seed core ingredient에는 사용하지 않습니다.
+- `fish`, `mushroom`, `cheese`는 broad key라서 FE는 세부 품종을 단정하지 않습니다.
+
+## Endpoints
+
+| Method | Path | FE 용도 |
+| --- | --- | --- |
+| `GET` | `/health` | 서버 상태 확인 |
+| `GET` | `/api/v1/inventory` | 현재 저장된 냉장고 재료 조회 |
+| `POST` | `/api/v1/inventory/bulk` | AI 감지 후보를 사용자가 확정 저장 |
+| `PATCH` | `/api/v1/inventory/quantity` | 재료 수량 +1/-1 |
+| `GET` | `/api/v1/stream/ingredients` | 식재료 감지 SSE 구독 |
+| `GET` | `/api/v1/stream/liquor` | 주류 감지 SSE 구독 |
+| `GET` | `/api/v1/stream/recommendations` | 추천 결과 SSE 구독 |
+| `POST` | `/api/v1/scan/liquor/start` | 수동 주류 스캔 fallback 시작 |
+| `GET` | `/api/v1/recommendations` | 주류 기준 추천 3개 조회 |
+
+## Inventory
+
+### GET `/api/v1/inventory`
+
+Response:
+
+```json
+{
+  "status": "success",
+  "data": [
+    {
+      "ingredient_name": "대파",
+      "quantity": 2,
+      "last_updated": "2026-04-27T12:00:00Z"
+    }
+  ]
+}
+```
+
+### POST `/api/v1/inventory/bulk`
+
+Request:
+
+```json
+{
+  "items": ["대파", "green_onion", "양파"]
+}
+```
+
+Response:
+
+```json
+{
+  "status": "success",
+  "message": "보관함에 저장되었습니다.",
+  "saved_count": 3
+}
+```
+
+### PATCH `/api/v1/inventory/quantity`
+
+Request:
+
+```json
+{
+  "ingredient_name": "대파",
+  "action": "add"
+}
+```
+
+Response:
+
+```json
+{
+  "status": "success",
+  "ingredient_name": "대파",
+  "current_quantity": 3
+}
+```
+
+## SSE
+
+SSE는 `text/event-stream`으로 연결합니다. 이벤트 payload는 JSON 문자열입니다.
+
+### GET `/api/v1/stream/ingredients`
+
+Example event data:
+
+```json
+{
+  "ingredient_name": "대파",
+  "timestamp": "2026-04-27T12:00:00Z"
+}
+```
+
+### GET `/api/v1/stream/liquor`
+
+Example event data:
+
+```json
+{
+  "liquor_name": "소주",
+  "timestamp": "2026-04-27T12:00:05Z"
+}
+```
+
+### GET `/api/v1/stream/recommendations`
+
+Event data shape is the same as `GET /api/v1/recommendations`.
+
+## Manual Liquor Scan
+
+### POST `/api/v1/scan/liquor/start`
+
+Request:
+
+```json
+{
+  "triggered_by": "frontend",
+  "device_id": "display-01"
+}
+```
+
+Response:
+
+```json
+{
+  "status": "accepted",
+  "message": "주류 스캔을 시작했습니다.",
+  "scan_request_id": "liquor-scan-20260427120000000"
+}
+```
+
+## Recommendations
+
+### GET `/api/v1/recommendations?liquor=soju&refresh=false`
+
+Query:
+
+| name | type | required | note |
+| --- | --- | --- | --- |
+| `liquor` | string | yes | 주류 key 또는 한국어 표시명 |
+| `refresh` | boolean | no | `true`면 같은 조건에서 다음 추천 묶음 조회 |
+
+Response 핵심 필드:
+
+```json
+{
+  "liquor": "소주",
+  "recommendations": [
+    {
+      "name": "돼지고기 대파 소금구이",
+      "reason": "소주와 잘 맞는 이유를 설명합니다.",
+      "priority_rank": 1,
+      "priority_reason": "현재 재료와 점수 기준으로 선택된 이유입니다.",
+      "selection_factors": ["필수 재료 3개 중 2개를 사용할 수 있어요."],
+      "score_breakdown": {
+        "available_ingredient_count": 2,
+        "missing_ingredient_count": 1,
+        "rank_hint": 95,
+        "total_score": 99
+      },
+      "servings": 1,
+      "cook_time_minutes": 15,
+      "difficulty": "easy",
+      "pairing_knowledge": {
+        "flavor_logic": "맛 관점 설명",
+        "ingredient_logic": "재료 관점 설명",
+        "why_this_liquor": "이 주류와 맞는 이유"
+      },
+      "ingredient_yes": ["대파", "상추"],
+      "ingredient_no": ["돼지고기"],
+      "ingredient_details": [
+        {
+          "item_name": "pork",
+          "display_name": "돼지고기",
+          "variant_detail": "구이용 목살 또는 앞다리살",
+          "amount": 220,
+          "unit": "g",
+          "status": "missing"
+        }
+      ],
+      "pantry_items": ["식용유 1큰술"],
+      "pantry_item_details": [
+        {"name": "식용유", "amount": 1, "unit": "큰술"}
+      ],
+      "recipe": ["1. 재료를 손질합니다."],
+      "recipe_steps": [
+        {
+          "step_number": 1,
+          "title": "재료 손질",
+          "instruction": "초보자도 따라할 수 있게 수량과 시간을 포함합니다.",
+          "time_minutes": 3,
+          "heat_level": "없음",
+          "success_cue": "재료 표면 물기가 거의 없으면 좋아요."
+        }
+      ],
+      "missing_ingredients": ["돼지고기"],
+      "tip": "조리 팁",
+      "tags": ["팬구이", "소주"]
+    }
+  ]
+}
+```
+

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -35,6 +35,9 @@ README_PATH = ROOT_DIR / "README.md"
 EVENT_ROUTE_PATH = ROOT_DIR / "app" / "api" / "routes" / "events.py"
 OPERATIONS_READINESS_PATH = ROOT_DIR / "docs" / "operations_readiness.md"
 DB_INIT_SCRIPT_PATH = ROOT_DIR / "scripts" / "initialize_database.py"
+FE_API_CONTRACT_PATH = ROOT_DIR / "docs" / "api_contract_fe.md"
+AI_API_CONTRACT_PATH = ROOT_DIR / "docs" / "api_contract_ai.md"
+API_CHANGE_WORKFLOW_PATH = ROOT_DIR / "docs" / "api_change_workflow.md"
 
 ALLOWED_INGREDIENT_KEYS = {
     "bacon",
@@ -373,6 +376,9 @@ class MappingQualityGateTest(unittest.TestCase):
     def test_ingredient_mapping_accepts_korean_and_internal_keys(self) -> None:
         self.assertEqual("green_onion", normalize_ingredient_key("대파"))
         self.assertEqual("green_onion", normalize_ingredient_key("green_onion"))
+        self.assertEqual("green_onion", normalize_ingredient_key("leek"))
+        self.assertEqual("green_onion", normalize_ingredient_key("scallion"))
+        self.assertEqual("green_onion", normalize_ingredient_key("spring_onion"))
         self.assertEqual("pepper", normalize_ingredient_key("파프리카"))
         self.assertEqual("대파", ingredient_display_name("green_onion"))
         self.assertEqual("파프리카", ingredient_display_name("pepper"))
@@ -457,6 +463,45 @@ class SwaggerDocumentationQualityGateTest(unittest.TestCase):
         example_text = json.dumps(example, ensure_ascii=False)
         self.assertNotIn('"liquor": "soju"', example_text)
         self.assertNotIn('"missing_ingredients": ["pork"', example_text)
+
+    def test_api_contract_docs_cover_fe_and_ai_handoff_fields(self) -> None:
+        fe_contract = FE_API_CONTRACT_PATH.read_text(encoding="utf-8")
+        ai_contract = AI_API_CONTRACT_PATH.read_text(encoding="utf-8")
+        workflow = API_CHANGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+        fe_required_terms = [
+            "`/api/v1/recommendations`",
+            "`/api/v1/stream/recommendations`",
+            "ingredient_yes",
+            "ingredient_no",
+            "missing_ingredients",
+            "ingredient_details[].status",
+            "pepper`는 고추가 아니라 파프리카",
+        ]
+        ai_required_terms = [
+            "POST `/api/v1/recognitions/ingredients`",
+            "POST `/api/v1/recognitions/liquor`",
+            "leek`, `scallion`, `spring_onion`",
+            "BE에서 `green_onion`으로 정규화",
+            "ginger`는 AI label에는 있을 수 있지만 추천 seed core ingredient로 사용하지 않습니다",
+            "soju, beer, red_wine, white_wine, sparkling_wine, whisky, sake",
+        ]
+        workflow_required_terms = [
+            "main 직접 push/merge 금지",
+            "새 기능/수정은 GitHub issue 먼저 생성",
+            "Sheet Template",
+            "기존 FE 응답 필드는 깨지지 않게 additive change 우선",
+        ]
+
+        for term in fe_required_terms:
+            with self.subTest(doc="fe", term=term):
+                self.assertIn(term, fe_contract)
+        for term in ai_required_terms:
+            with self.subTest(doc="ai", term=term):
+                self.assertIn(term, ai_contract)
+        for term in workflow_required_terms:
+            with self.subTest(doc="workflow", term=term):
+                self.assertIn(term, workflow)
 
     def test_readme_recommendation_example_uses_display_values(self) -> None:
         readme_text = README_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #16

- FE/AI API 계약 문서 추가
- API 변경 요청 workflow 문서 추가
- leek/scallion/spring_onion을 green_onion으로 정규화
- pytest: 29 passed