### PR TITLE
[BE] FE 신규 API 명세 연동

### DIFF
--- a/app/api/router.py
+++ b/app/api/router.py
@@ -1,6 +1,7 @@
 ﻿from fastapi import APIRouter
 
 from app.api.routes.events import router as events_router
+from app.api.routes.favorite_recipe import router as favorite_recipe_router
 from app.api.routes.health import router as health_router
 from app.api.routes.inventory import router as inventory_router
 from app.api.routes.recognition import router as recognition_router
@@ -14,3 +15,4 @@ api_router.include_router(inventory_router)
 api_router.include_router(events_router)
 api_router.include_router(recommendation_router)
 api_router.include_router(scan_router)
+api_router.include_router(favorite_recipe_router)

--- a/app/api/routes/favorite_recipe.py
+++ b/app/api/routes/favorite_recipe.py
@@ -1,0 +1,67 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_db
+from app.repositories.favorite_recipe_repository import FavoriteRecipeRepository
+from app.schemas.favorite_recipe import (
+    FavoriteRecipeCreate,
+    FavoriteRecipeCreateResponse,
+    FavoriteRecipeDeleteResponse,
+    FavoriteRecipeDetailResponse,
+    FavoriteRecipeListResponse,
+)
+from app.services.favorite_recipe_service import FavoriteRecipeService
+
+router = APIRouter(prefix="/api/v1/favorite-recipes", tags=["즐겨찾기 레시피"])
+
+
+def _service(db: Session) -> FavoriteRecipeService:
+    return FavoriteRecipeService(db, FavoriteRecipeRepository(db))
+
+
+@router.post(
+    "",
+    response_model=FavoriteRecipeCreateResponse,
+    status_code=201,
+    summary="즐겨찾기 레시피 저장",
+)
+def create_favorite_recipe(
+    payload: FavoriteRecipeCreate,
+    db: Session = Depends(get_db),
+) -> FavoriteRecipeCreateResponse:
+    return _service(db).create_favorite(payload)
+
+
+@router.get(
+    "",
+    response_model=FavoriteRecipeListResponse,
+    summary="즐겨찾기 레시피 목록 조회",
+)
+def list_favorite_recipes(
+    db: Session = Depends(get_db),
+) -> FavoriteRecipeListResponse:
+    return _service(db).list_favorites()
+
+
+@router.get(
+    "/{favorite_id}",
+    response_model=FavoriteRecipeDetailResponse,
+    summary="즐겨찾기 레시피 상세 조회",
+)
+def get_favorite_recipe(
+    favorite_id: int,
+    db: Session = Depends(get_db),
+) -> FavoriteRecipeDetailResponse:
+    return _service(db).get_favorite(favorite_id)
+
+
+@router.delete(
+    "/{favorite_id}",
+    response_model=FavoriteRecipeDeleteResponse,
+    summary="즐겨찾기 레시피 삭제",
+)
+def delete_favorite_recipe(
+    favorite_id: int,
+    db: Session = Depends(get_db),
+) -> FavoriteRecipeDeleteResponse:
+    return _service(db).delete_favorite(favorite_id)

--- a/app/api/routes/inventory.py
+++ b/app/api/routes/inventory.py
@@ -6,9 +6,13 @@ from app.repositories.inventory_repository import InventoryRepository
 from app.schemas.inventory import (
     InventoryBulkCreate,
     InventoryBulkResponse,
+    InventoryCreateRequest,
+    InventoryDeleteResponse,
     InventoryListResponse,
+    InventoryMutationResponse,
     InventoryQuantityPatchRequest,
     InventoryQuantityPatchResponse,
+    InventoryUpdateRequest,
 )
 from app.services.inventory_service import InventoryService
 
@@ -49,6 +53,22 @@ def bulk_save_inventory(
     return service.bulk_save_inventory(payload)
 
 
+@router.post(
+    "",
+    response_model=InventoryMutationResponse,
+    status_code=201,
+    summary="식재료 직접 추가",
+    description="사용자가 식재료 이름과 수량을 직접 입력해 DB에 추가합니다.",
+)
+def add_inventory_item(
+    payload: InventoryCreateRequest,
+    db: Session = Depends(get_db),
+) -> InventoryMutationResponse:
+    repository = InventoryRepository(db)
+    service = InventoryService(db, repository)
+    return service.add_inventory_item(payload)
+
+
 @router.patch(
     "/quantity",
     response_model=InventoryQuantityPatchResponse,
@@ -66,3 +86,34 @@ def patch_inventory_quantity(
     repository = InventoryRepository(db)
     service = InventoryService(db, repository)
     return service.patch_inventory_quantity(payload)
+
+
+@router.patch(
+    "/{ingredient_name}",
+    response_model=InventoryMutationResponse,
+    summary="식재료 이름/수량 직접 수정",
+    description="사용자가 식재료 이름 또는 수량을 직접 수정합니다.",
+)
+def update_inventory_item(
+    ingredient_name: str,
+    payload: InventoryUpdateRequest,
+    db: Session = Depends(get_db),
+) -> InventoryMutationResponse:
+    repository = InventoryRepository(db)
+    service = InventoryService(db, repository)
+    return service.update_inventory_item(ingredient_name, payload)
+
+
+@router.delete(
+    "/{ingredient_name}",
+    response_model=InventoryDeleteResponse,
+    summary="식재료 삭제",
+    description="사용자가 식재료를 DB에서 삭제합니다.",
+)
+def delete_inventory_item(
+    ingredient_name: str,
+    db: Session = Depends(get_db),
+) -> InventoryDeleteResponse:
+    repository = InventoryRepository(db)
+    service = InventoryService(db, repository)
+    return service.delete_inventory_item(ingredient_name)

--- a/app/api/routes/recommendation.py
+++ b/app/api/routes/recommendation.py
@@ -2,7 +2,11 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.dependencies import get_db
-from app.schemas.recommendation import RecommendationsResponse
+from app.schemas.recommendation import (
+    RecommendationRefreshRequest,
+    RecommendationRefreshResponse,
+    RecommendationsResponse,
+)
 from app.services.recommendation_service import RecommendationService
 
 router = APIRouter(prefix="/api/v1/recommendations", tags=["추천"])
@@ -29,3 +33,17 @@ def get_recommendations(
 ) -> RecommendationsResponse:
     service = RecommendationService(db)
     return service.get_recommendations(liquor=liquor, refresh=refresh)
+
+
+@router.post(
+    "/refresh",
+    response_model=RecommendationRefreshResponse,
+    summary="고정 추천 제외 재추천",
+    description="고정된 추천은 유지하고 나머지만 새 추천으로 채워 총 3개를 반환합니다.",
+)
+def refresh_recommendations(
+    payload: RecommendationRefreshRequest,
+    db: Session = Depends(get_db),
+) -> RecommendationRefreshResponse:
+    service = RecommendationService(db)
+    return service.refresh_with_keep(payload)

--- a/app/api/routes/scan.py
+++ b/app/api/routes/scan.py
@@ -1,6 +1,11 @@
 from fastapi import APIRouter
 
-from app.schemas.recognition import LiquorScanStartRequest, LiquorScanStartResponse
+from app.schemas.recognition import (
+    IngredientScanStartRequest,
+    IngredientScanStartResponse,
+    LiquorScanStartRequest,
+    LiquorScanStartResponse,
+)
 from app.services.recognition_service import RecognitionService
 
 router = APIRouter(prefix="/api/v1/scan", tags=["스캔 요청"])
@@ -21,3 +26,17 @@ async def start_liquor_scan(
 ) -> LiquorScanStartResponse:
     service = RecognitionService()
     return await service.start_liquor_scan(payload)
+
+
+@router.post(
+    "/ingredients/start",
+    response_model=IngredientScanStartResponse,
+    summary="식재료 스캔 요청",
+    description="홈 화면에서 식재료 스캔 버튼을 누르면 식재료 인식 mock 흐름을 시작합니다.",
+    response_description="식재료 스캔 요청 접수 결과와 scan_request_id를 반환합니다.",
+)
+async def start_ingredient_scan(
+    payload: IngredientScanStartRequest,
+) -> IngredientScanStartResponse:
+    service = RecognitionService()
+    return await service.start_ingredient_scan(payload)

--- a/app/domain/models.py
+++ b/app/domain/models.py
@@ -77,3 +77,18 @@ class RecipeIngredient(Base):
     unit: Mapped[str] = mapped_column(String(20), default="개")
 
     recipe: Mapped["Recipe"] = relationship(back_populates="ingredients")
+
+
+class FavoriteRecipe(Base):
+    __tablename__ = "favorite_recipes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    liquor: Mapped[str] = mapped_column(String(50), index=True)
+    name: Mapped[str] = mapped_column(String(200), index=True)
+    reason: Mapped[str] = mapped_column(Text, default="")
+    ingredient_yes_text: Mapped[str] = mapped_column(Text, default="[]")
+    ingredient_no_text: Mapped[str] = mapped_column(Text, default="[]")
+    recipe_text: Mapped[str] = mapped_column(Text, default="[]")
+    missing_ingredients_text: Mapped[str] = mapped_column(Text, default="[]")
+    payload_text: Mapped[str] = mapped_column(Text, default="{}")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)

--- a/app/repositories/favorite_recipe_repository.py
+++ b/app/repositories/favorite_recipe_repository.py
@@ -1,0 +1,26 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.domain.models import FavoriteRecipe
+
+
+class FavoriteRecipeRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create(self, favorite: FavoriteRecipe) -> FavoriteRecipe:
+        self.db.add(favorite)
+        self.db.flush()
+        return favorite
+
+    def list_all(self) -> list[FavoriteRecipe]:
+        stmt = select(FavoriteRecipe).order_by(FavoriteRecipe.created_at.desc())
+        return list(self.db.scalars(stmt).all())
+
+    def get(self, favorite_id: int) -> FavoriteRecipe | None:
+        stmt = select(FavoriteRecipe).where(FavoriteRecipe.id == favorite_id)
+        return self.db.scalar(stmt)
+
+    def delete(self, favorite: FavoriteRecipe) -> None:
+        self.db.delete(favorite)
+        self.db.flush()

--- a/app/repositories/inventory_repository.py
+++ b/app/repositories/inventory_repository.py
@@ -28,6 +28,27 @@ class InventoryRepository:
         self.db.flush()
         return item
 
+    def set_inventory_count(self, item_name: str, quantity: int) -> InventoryItem:
+        item = self.get_inventory_item(item_name)
+        if item is None:
+            item = InventoryItem(item_name=item_name, count=max(quantity, 0))
+            self.db.add(item)
+            self.db.flush()
+            return item
+
+        item.count = max(quantity, 0)
+        self.db.flush()
+        return item
+
+    def delete_inventory_item(self, item_name: str) -> bool:
+        item = self.get_inventory_item(item_name)
+        if item is None:
+            return False
+
+        self.db.delete(item)
+        self.db.flush()
+        return True
+
     def create_event(
         self,
         *,

--- a/app/schemas/favorite_recipe.py
+++ b/app/schemas/favorite_recipe.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class FavoriteRecipeCreate(BaseModel):
+    liquor: str = Field(min_length=1, max_length=100)
+    name: str = Field(min_length=1, max_length=200)
+    reason: str = ""
+    ingredient_yes: list[str] = Field(default_factory=list)
+    ingredient_no: list[str] = Field(default_factory=list)
+    recipe: list[str] = Field(default_factory=list)
+    missing_ingredients: list[str] = Field(default_factory=list)
+
+    model_config = {"extra": "allow"}
+
+
+class FavoriteRecipeCreateResponse(BaseModel):
+    status: Literal["success"]
+    message: str
+    favorite_id: int
+
+
+class FavoriteRecipeData(BaseModel):
+    favorite_id: int
+    liquor: str
+    name: str
+    reason: str
+    ingredient_yes: list[str]
+    ingredient_no: list[str]
+    recipe: list[str]
+    missing_ingredients: list[str]
+    created_at: datetime
+
+    model_config = {"extra": "allow"}
+
+
+class FavoriteRecipeListResponse(BaseModel):
+    status: Literal["success"]
+    data: list[dict[str, Any]]
+
+
+class FavoriteRecipeDetailResponse(BaseModel):
+    status: Literal["success"]
+    data: dict[str, Any]
+
+
+class FavoriteRecipeDeleteResponse(BaseModel):
+    status: Literal["success"]
+    message: str

--- a/app/schemas/inventory.py
+++ b/app/schemas/inventory.py
@@ -41,6 +41,28 @@ class InventoryBulkResponse(BaseModel):
     saved_count: int = Field(description="배열 기준으로 저장 처리된 총 식재료 항목 수입니다.")
 
 
+class InventoryCreateRequest(BaseModel):
+    ingredient_name: str = Field(min_length=1, max_length=100)
+    quantity: int = Field(default=1, ge=0)
+
+
+class InventoryUpdateRequest(BaseModel):
+    new_ingredient_name: str | None = Field(default=None, min_length=1, max_length=100)
+    quantity: int | None = Field(default=None, ge=0)
+
+
+class InventoryMutationResponse(BaseModel):
+    status: Literal["success"]
+    message: str
+    ingredient_name: str
+    current_quantity: int
+
+
+class InventoryDeleteResponse(BaseModel):
+    status: Literal["success"]
+    message: str
+
+
 class InventoryQuantityPatchRequest(BaseModel):
     ingredient_name: str = Field(
         min_length=1,

--- a/app/schemas/inventory.py
+++ b/app/schemas/inventory.py
@@ -47,6 +47,7 @@ class InventoryCreateRequest(BaseModel):
 
 
 class InventoryUpdateRequest(BaseModel):
+    ingredient_name: str | None = Field(default=None, min_length=1, max_length=100)
     new_ingredient_name: str | None = Field(default=None, min_length=1, max_length=100)
     quantity: int | None = Field(default=None, ge=0)
 

--- a/app/schemas/recognition.py
+++ b/app/schemas/recognition.py
@@ -29,6 +29,7 @@ class IngredientLiveRecognitionCreate(BaseModel):
         description="이 인식 결과를 보낸 모델 또는 서비스 이름입니다.",
         examples=["ingredient_classifier"],
     )
+    scan_request_id: str | None = Field(default=None, max_length=100)
 
     model_config = {
         "json_schema_extra": {
@@ -45,6 +46,7 @@ class IngredientLiveRecognitionCreate(BaseModel):
 class IngredientStreamEvent(BaseModel):
     ingredient_name: str = Field(description="실시간으로 감지된 식재료 한글 이름입니다.")
     timestamp: datetime = Field(description="해당 식재료 이벤트가 발생한 시각입니다.")
+    scan_request_id: str | None = Field(default=None)
 
 
 class LiquorLiveRecognitionCreate(BaseModel):
@@ -72,6 +74,7 @@ class LiquorLiveRecognitionCreate(BaseModel):
         description="이 인식 결과를 보낸 모델 또는 서비스 이름입니다.",
         examples=["liquor_classifier"],
     )
+    scan_request_id: str | None = Field(default=None, max_length=100)
 
     model_config = {
         "json_schema_extra": {
@@ -88,6 +91,7 @@ class LiquorLiveRecognitionCreate(BaseModel):
 class LiquorStreamEvent(BaseModel):
     liquor_name: str = Field(description="실시간으로 감지된 주류 한글 이름입니다.")
     timestamp: datetime = Field(description="해당 주류 이벤트가 발생한 시각입니다.")
+    scan_request_id: str | None = Field(default=None)
 
 
 class LiveRecognitionAcceptedResponse(BaseModel):
@@ -125,3 +129,13 @@ class LiquorScanStartResponse(BaseModel):
     )
     message: str = Field(description="주류 스캔 시작 처리 결과 메시지입니다.")
     scan_request_id: str = Field(description="이번 주류 스캔 요청을 식별하는 ID입니다.")
+
+
+class IngredientScanStartRequest(LiquorScanStartRequest):
+    pass
+
+
+class IngredientScanStartResponse(BaseModel):
+    status: Literal["accepted"]
+    message: str
+    scan_request_id: str

--- a/app/schemas/recommendation.py
+++ b/app/schemas/recommendation.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 
@@ -206,3 +208,14 @@ class RecommendationsResponse(BaseModel):
             "example": RECOMMENDATIONS_RESPONSE_EXAMPLE,
         }
     }
+
+
+class RecommendationRefreshRequest(BaseModel):
+    liquor: str = Field(min_length=1, max_length=100)
+    keep_recommendations: list[dict[str, Any]] = Field(default_factory=list)
+    refresh_count: int = Field(default=1, ge=0, le=3)
+
+
+class RecommendationRefreshResponse(BaseModel):
+    liquor: str
+    recommendations: list[dict[str, Any]]

--- a/app/services/favorite_recipe_service.py
+++ b/app/services/favorite_recipe_service.py
@@ -1,0 +1,113 @@
+import json
+from typing import Any
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.domain.models import FavoriteRecipe
+from app.repositories.favorite_recipe_repository import FavoriteRecipeRepository
+from app.schemas.favorite_recipe import (
+    FavoriteRecipeCreate,
+    FavoriteRecipeCreateResponse,
+    FavoriteRecipeDeleteResponse,
+    FavoriteRecipeDetailResponse,
+    FavoriteRecipeListResponse,
+)
+
+
+class FavoriteRecipeService:
+    def __init__(self, db: Session, repository: FavoriteRecipeRepository):
+        self.db = db
+        self.repository = repository
+
+    @staticmethod
+    def _json_list(items: list[str]) -> str:
+        return json.dumps(items, ensure_ascii=False)
+
+    @staticmethod
+    def _load_json(value: str | None, fallback: Any) -> Any:
+        if not value:
+            return fallback
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return fallback
+
+    @classmethod
+    def _to_payload(cls, favorite: FavoriteRecipe) -> dict[str, Any]:
+        payload = cls._load_json(favorite.payload_text, {})
+        if not isinstance(payload, dict):
+            payload = {}
+
+        payload.update(
+            {
+                "favorite_id": favorite.id,
+                "liquor": favorite.liquor,
+                "name": favorite.name,
+                "reason": favorite.reason,
+                "ingredient_yes": cls._load_json(favorite.ingredient_yes_text, []),
+                "ingredient_no": cls._load_json(favorite.ingredient_no_text, []),
+                "recipe": cls._load_json(favorite.recipe_text, []),
+                "missing_ingredients": cls._load_json(
+                    favorite.missing_ingredients_text,
+                    [],
+                ),
+                "created_at": favorite.created_at,
+            }
+        )
+        return payload
+
+    def create_favorite(
+        self, payload: FavoriteRecipeCreate
+    ) -> FavoriteRecipeCreateResponse:
+        payload_dict = payload.model_dump(mode="json")
+        favorite = FavoriteRecipe(
+            liquor=payload.liquor,
+            name=payload.name,
+            reason=payload.reason,
+            ingredient_yes_text=self._json_list(payload.ingredient_yes),
+            ingredient_no_text=self._json_list(payload.ingredient_no),
+            recipe_text=self._json_list(payload.recipe),
+            missing_ingredients_text=self._json_list(payload.missing_ingredients),
+            payload_text=json.dumps(payload_dict, ensure_ascii=False),
+        )
+        self.repository.create(favorite)
+        self.db.commit()
+        self.db.refresh(favorite)
+        return FavoriteRecipeCreateResponse(
+            status="success",
+            message="즐겨찾기 레시피에 저장되었습니다.",
+            favorite_id=favorite.id,
+        )
+
+    def list_favorites(self) -> FavoriteRecipeListResponse:
+        return FavoriteRecipeListResponse(
+            status="success",
+            data=[
+                self._to_payload(favorite)
+                for favorite in self.repository.list_all()
+            ],
+        )
+
+    def get_favorite(self, favorite_id: int) -> FavoriteRecipeDetailResponse:
+        favorite = self.repository.get(favorite_id)
+        if favorite is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="즐겨찾기 레시피를 찾을 수 없습니다.",
+            )
+        return FavoriteRecipeDetailResponse(
+            status="success",
+            data=self._to_payload(favorite),
+        )
+
+    def delete_favorite(self, favorite_id: int) -> FavoriteRecipeDeleteResponse:
+        favorite = self.repository.get(favorite_id)
+        if favorite is not None:
+            self.repository.delete(favorite)
+            self.db.commit()
+
+        return FavoriteRecipeDeleteResponse(
+            status="success",
+            message="즐겨찾기 레시피에서 삭제되었습니다.",
+        )

--- a/app/services/favorite_recipe_service.py
+++ b/app/services/favorite_recipe_service.py
@@ -41,7 +41,8 @@ class FavoriteRecipeService:
 
         payload.update(
             {
-                "favorite_id": favorite.id,
+                "favorite_id": str(favorite.id),
+                "id": str(favorite.id),
                 "liquor": favorite.liquor,
                 "name": favorite.name,
                 "reason": favorite.reason,

--- a/app/services/inventory_service.py
+++ b/app/services/inventory_service.py
@@ -6,10 +6,14 @@ from app.repositories.inventory_repository import InventoryRepository
 from app.schemas.inventory import (
     InventoryBulkCreate,
     InventoryBulkResponse,
+    InventoryCreateRequest,
+    InventoryDeleteResponse,
     InventoryItemData,
     InventoryListResponse,
+    InventoryMutationResponse,
     InventoryQuantityPatchRequest,
     InventoryQuantityPatchResponse,
+    InventoryUpdateRequest,
 )
 from app.services.name_mapping import ingredient_display_name, normalize_ingredient_key
 
@@ -89,6 +93,85 @@ class InventoryService:
             status="success",
             message="보관함에 저장되었습니다.",
             saved_count=len(normalized_items),
+        )
+
+    def _current_quantity(self, ingredient_name: str) -> int:
+        return sum(
+            item.count
+            for item in self.repository.list_inventory_items()
+            if normalize_ingredient_key(item.item_name) == ingredient_name
+        )
+
+    def add_inventory_item(
+        self, payload: InventoryCreateRequest
+    ) -> InventoryMutationResponse:
+        ingredient_name = normalize_ingredient_key(payload.ingredient_name)
+        inventory_item = self.repository.upsert_inventory_count(
+            ingredient_name,
+            payload.quantity,
+        )
+        self.repository.create_event(
+            item_name=ingredient_name,
+            event_type="manual_add",
+            quantity=payload.quantity,
+            confidence=1.0,
+            source="manual_inventory_create",
+            detected_at=inventory_item.updated_at,
+        )
+        self.db.commit()
+        self.db.refresh(inventory_item)
+
+        return InventoryMutationResponse(
+            status="success",
+            message="식재료가 추가되었습니다.",
+            ingredient_name=ingredient_display_name(ingredient_name),
+            current_quantity=self._current_quantity(ingredient_name),
+        )
+
+    def update_inventory_item(
+        self,
+        ingredient_name: str,
+        payload: InventoryUpdateRequest,
+    ) -> InventoryMutationResponse:
+        current_name = normalize_ingredient_key(ingredient_name)
+        new_name = (
+            normalize_ingredient_key(payload.new_ingredient_name)
+            if payload.new_ingredient_name
+            else current_name
+        )
+        current_item = self.repository.get_inventory_item(current_name)
+        current_quantity = current_item.count if current_item else 0
+        new_quantity = payload.quantity if payload.quantity is not None else current_quantity
+
+        if new_name != current_name:
+            self.repository.delete_inventory_item(current_name)
+
+        inventory_item = self.repository.set_inventory_count(new_name, new_quantity)
+        self.repository.create_event(
+            item_name=new_name,
+            event_type="manual_update",
+            quantity=new_quantity,
+            confidence=1.0,
+            source="manual_inventory_update",
+            detected_at=inventory_item.updated_at,
+        )
+        self.db.commit()
+        self.db.refresh(inventory_item)
+
+        return InventoryMutationResponse(
+            status="success",
+            message="식재료가 수정되었습니다.",
+            ingredient_name=ingredient_display_name(new_name),
+            current_quantity=self._current_quantity(new_name),
+        )
+
+    def delete_inventory_item(self, ingredient_name: str) -> InventoryDeleteResponse:
+        normalized = normalize_ingredient_key(ingredient_name)
+        self.repository.delete_inventory_item(normalized)
+        self.db.commit()
+        return InventoryDeleteResponse(
+            status="success",
+            message="식재료가 삭제되었습니다.",
         )
 
     def patch_inventory_quantity(

--- a/app/services/inventory_service.py
+++ b/app/services/inventory_service.py
@@ -134,9 +134,10 @@ class InventoryService:
         payload: InventoryUpdateRequest,
     ) -> InventoryMutationResponse:
         current_name = normalize_ingredient_key(ingredient_name)
+        requested_name = payload.new_ingredient_name or payload.ingredient_name
         new_name = (
-            normalize_ingredient_key(payload.new_ingredient_name)
-            if payload.new_ingredient_name
+            normalize_ingredient_key(requested_name)
+            if requested_name
             else current_name
         )
         current_item = self.repository.get_inventory_item(current_name)

--- a/app/services/recognition_service.py
+++ b/app/services/recognition_service.py
@@ -5,6 +5,8 @@ from random import choice
 from app.db import SessionLocal
 from app.schemas.recognition import (
     IngredientLiveRecognitionCreate,
+    IngredientScanStartRequest,
+    IngredientScanStartResponse,
     IngredientStreamEvent,
     LiquorLiveRecognitionCreate,
     LiquorScanStartRequest,
@@ -36,6 +38,16 @@ MOCK_LIQUOR_SCAN_CANDIDATES: tuple[str, ...] = (
     "sake",
 )
 
+MOCK_INGREDIENT_SCAN_CANDIDATES: tuple[str, ...] = (
+    "green_onion",
+    "onion",
+    "garlic",
+    "egg",
+    "pork",
+    "potato",
+    "mushroom",
+)
+
 
 class RecognitionService:
     async def publish_ingredient_live_result(
@@ -45,6 +57,7 @@ class RecognitionService:
         event_payload = IngredientStreamEvent(
             ingredient_name=ingredient_display_name(ingredient_key),
             timestamp=payload.timestamp,
+            scan_request_id=payload.scan_request_id,
         )
         await ingredient_event_broker.publish(event_payload.model_dump(mode="json"))
         return LiveRecognitionAcceptedResponse(
@@ -59,6 +72,7 @@ class RecognitionService:
         event_payload = LiquorStreamEvent(
             liquor_name=liquor_display_name(liquor_key),
             timestamp=payload.timestamp,
+            scan_request_id=payload.scan_request_id,
         )
         await liquor_event_broker.publish(event_payload.model_dump(mode="json"))
         asyncio.create_task(self._publish_recommendation_event(liquor_key))
@@ -73,14 +87,29 @@ class RecognitionService:
         scan_request_id = (
             f"liquor-scan-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S%f')[:-3]}"
         )
-        asyncio.create_task(self._mock_liquor_scan_flow(payload.device_id))
+        asyncio.create_task(self._mock_liquor_scan_flow(payload.device_id, scan_request_id))
         return LiquorScanStartResponse(
             status="accepted",
             message="주류 스캔을 시작했습니다.",
             scan_request_id=scan_request_id,
         )
 
-    async def _mock_liquor_scan_flow(self, device_id: str) -> None:
+    async def start_ingredient_scan(
+        self, payload: IngredientScanStartRequest
+    ) -> IngredientScanStartResponse:
+        scan_request_id = (
+            f"ingredient-scan-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S%f')[:-3]}"
+        )
+        asyncio.create_task(
+            self._mock_ingredient_scan_flow(payload.device_id, scan_request_id)
+        )
+        return IngredientScanStartResponse(
+            status="accepted",
+            message="식재료 스캔을 시작했습니다.",
+            scan_request_id=scan_request_id,
+        )
+
+    async def _mock_liquor_scan_flow(self, device_id: str, scan_request_id: str) -> None:
         # FE가 스캔 중 상태를 잠깐 보여줄 수 있도록 약간의 지연 후
         # mock 주류 인식 결과를 발행합니다.
         await asyncio.sleep(3.0)
@@ -89,8 +118,22 @@ class RecognitionService:
             timestamp=datetime.now(timezone.utc),
             confidence=0.99,
             source=f"manual_scan_mock:{device_id}",
+            scan_request_id=scan_request_id,
         )
         await self.publish_liquor_live_result(payload)
+
+    async def _mock_ingredient_scan_flow(
+        self, device_id: str, scan_request_id: str
+    ) -> None:
+        await asyncio.sleep(1.0)
+        payload = IngredientLiveRecognitionCreate(
+            ingredient_name=choice(MOCK_INGREDIENT_SCAN_CANDIDATES),
+            timestamp=datetime.now(timezone.utc),
+            confidence=0.98,
+            source=f"manual_scan_mock:{device_id}",
+            scan_request_id=scan_request_id,
+        )
+        await self.publish_ingredient_live_result(payload)
 
     async def _publish_recommendation_event(self, liquor_name: str) -> None:
         liquor_key = normalize_liquor_key(liquor_name)

--- a/app/services/recommendation_service.py
+++ b/app/services/recommendation_service.py
@@ -13,6 +13,8 @@ from app.schemas.recommendation import (
     RecommendationPairingKnowledge,
     RecommendationPantryItem,
     RecommendationRecipeStep,
+    RecommendationRefreshRequest,
+    RecommendationRefreshResponse,
     RecommendationScoreBreakdown,
     RecommendationsResponse,
 )
@@ -327,4 +329,56 @@ class RecommendationService:
         return RecommendationsResponse(
             liquor=liquor_display_name(normalized),
             recommendations=recommendations,
+        )
+
+    def refresh_with_keep(
+        self, payload: RecommendationRefreshRequest
+    ) -> RecommendationRefreshResponse:
+        normalized = normalize_liquor_key(payload.liquor or "soju") or "soju"
+        kept = payload.keep_recommendations[:3]
+        kept_names = {
+            str(item.get("name"))
+            for item in kept
+            if isinstance(item, dict) and item.get("name")
+        }
+        needed_count = min(payload.refresh_count, max(3 - len(kept), 0))
+        fresh_items: list[dict[str, Any]] = []
+
+        for attempt in range(10):
+            if len(fresh_items) >= needed_count:
+                break
+
+            response = self.get_recommendations(normalized, refresh=True)
+            for recommendation in response.recommendations:
+                item = recommendation.model_dump(mode="json")
+                name = str(item.get("name") or "")
+                if not name or name in kept_names:
+                    continue
+                if any(existing.get("name") == name for existing in fresh_items):
+                    continue
+
+                fresh_items.append(item)
+                if len(fresh_items) >= needed_count:
+                    break
+
+            if attempt >= 2 and not fresh_items:
+                break
+
+        combined = kept + fresh_items
+        if len(combined) < 3:
+            response = self.get_recommendations(normalized, refresh=True)
+            for recommendation in response.recommendations:
+                item = recommendation.model_dump(mode="json")
+                name = str(item.get("name") or "")
+                if name in kept_names:
+                    continue
+                if any(existing.get("name") == name for existing in combined):
+                    continue
+                combined.append(item)
+                if len(combined) >= 3:
+                    break
+
+        return RecommendationRefreshResponse(
+            liquor=liquor_display_name(normalized),
+            recommendations=combined[:3],
         )

--- a/docs/api_contract_fe.md
+++ b/docs/api_contract_fe.md
@@ -153,6 +153,31 @@ Example event data:
 
 Event data shape is the same as `GET /api/v1/recommendations`.
 
+## FE Sheet Additions
+
+The following endpoints are additive and keep the existing response fields stable.
+
+### POST `/api/v1/scan/ingredients/start`
+
+Starts a manual ingredient scan and returns `scan_request_id`. The ingredient SSE payload includes the same `scan_request_id` so FE can connect the button request to the streamed result.
+
+### Inventory CRUD
+
+- `POST /api/v1/inventory`: manually add one item with `ingredient_name` and `quantity`.
+- `PATCH /api/v1/inventory/{ingredient_name}`: rename an item and/or set quantity directly.
+- `DELETE /api/v1/inventory/{ingredient_name}`: delete one item.
+
+### Favorite Recipes
+
+- `POST /api/v1/favorite-recipes`: save a recommendation payload.
+- `GET /api/v1/favorite-recipes`: list saved recipes.
+- `GET /api/v1/favorite-recipes/{favorite_id}`: get one saved recipe.
+- `DELETE /api/v1/favorite-recipes/{favorite_id}`: remove one saved recipe.
+
+### POST `/api/v1/recommendations/refresh`
+
+Keeps `keep_recommendations` and fills the remaining slots up to 3 recommendations. Existing recommendation fields such as `name`, `reason`, `ingredient_yes`, `ingredient_no`, `recipe`, and `missing_ingredients` are preserved. Expanded fields such as `ingredient_details`, `recipe_steps`, `priority_rank`, `selection_factors`, `score_breakdown`, and `pantry_items` are also returned when BE selects new recommendations.
+
 ## Manual Liquor Scan
 
 ### POST `/api/v1/scan/liquor/start`

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -632,6 +632,10 @@ class ServiceQualityGateTest(unittest.TestCase):
             "마늘",
             InventoryUpdateRequest(new_ingredient_name="대파", quantity=5),
         )
+        renamed = service.update_inventory_item(
+            "대파",
+            InventoryUpdateRequest(ingredient_name="양파", quantity=2),
+        )
         service.delete_inventory_item("대파")
         quantities = {
             item.ingredient_name: item.quantity
@@ -644,6 +648,9 @@ class ServiceQualityGateTest(unittest.TestCase):
         self.assertEqual("success", updated.status)
         self.assertEqual("대파", updated.ingredient_name)
         self.assertEqual(5, updated.current_quantity)
+        self.assertEqual("양파", renamed.ingredient_name)
+        self.assertEqual(2, renamed.current_quantity)
+        self.assertIn("양파", quantities)
         self.assertNotIn("대파", quantities)
 
     def test_favorite_recipe_crud_preserves_recommendation_payload(self) -> None:

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -13,10 +13,15 @@ from sqlalchemy.orm import sessionmaker
 
 from app.db import Base
 from app.domain.models import InventoryItem
+from app.repositories.favorite_recipe_repository import FavoriteRecipeRepository
 from app.repositories.inventory_repository import InventoryRepository
 from app.seeds.recommendation_seed import seed_recommendation_data
+from app.schemas.favorite_recipe import FavoriteRecipeCreate
 from app.schemas.inventory import InventoryBulkCreate
-from app.schemas.recommendation import RecommendationsResponse
+from app.schemas.inventory import InventoryCreateRequest, InventoryUpdateRequest
+from app.schemas.recognition import IngredientStreamEvent, LiquorStreamEvent
+from app.schemas.recommendation import RecommendationRefreshRequest, RecommendationsResponse
+from app.services.favorite_recipe_service import FavoriteRecipeService
 from app.services.inventory_service import InventoryService
 from app.services.name_mapping import (
     ingredient_display_name,
@@ -24,7 +29,10 @@ from app.services.name_mapping import (
     normalize_ingredient_key,
     normalize_liquor_key,
 )
-from app.services.recognition_service import MOCK_LIQUOR_SCAN_CANDIDATES
+from app.services.recognition_service import (
+    MOCK_INGREDIENT_SCAN_CANDIDATES,
+    MOCK_LIQUOR_SCAN_CANDIDATES,
+)
 from app.services.recommendation_service import RecommendationService
 
 
@@ -400,6 +408,27 @@ class MappingQualityGateTest(unittest.TestCase):
         )
         self.assertEqual(7, len(MOCK_LIQUOR_SCAN_CANDIDATES))
 
+    def test_manual_ingredient_scan_mock_uses_supported_keys(self) -> None:
+        self.assertGreaterEqual(len(MOCK_INGREDIENT_SCAN_CANDIDATES), 3)
+        self.assertTrue(
+            set(MOCK_INGREDIENT_SCAN_CANDIDATES).issubset(ALLOWED_INGREDIENT_KEYS)
+        )
+
+    def test_stream_events_include_scan_request_id(self) -> None:
+        ingredient_event = IngredientStreamEvent(
+            ingredient_name="대파",
+            timestamp="2026-04-10T17:16:01Z",
+            scan_request_id="ingredient-scan-001",
+        )
+        liquor_event = LiquorStreamEvent(
+            liquor_name="소주",
+            timestamp="2026-04-10T17:20:00Z",
+            scan_request_id="liquor-scan-001",
+        )
+
+        self.assertEqual("ingredient-scan-001", ingredient_event.scan_request_id)
+        self.assertEqual("liquor-scan-001", liquor_event.scan_request_id)
+
 
 class PolicyDocumentationQualityGateTest(unittest.TestCase):
     def test_recommendation_policy_documents_seed_and_scoring_rules(self) -> None:
@@ -593,6 +622,58 @@ class ServiceQualityGateTest(unittest.TestCase):
         self.assertEqual(2, quantities["대파"])
         self.assertEqual(1, quantities["양파"])
 
+    def test_inventory_manual_crud_supports_fe_contract(self) -> None:
+        service = InventoryService(self.db, InventoryRepository(self.db))
+
+        created = service.add_inventory_item(
+            InventoryCreateRequest(ingredient_name="마늘", quantity=3)
+        )
+        updated = service.update_inventory_item(
+            "마늘",
+            InventoryUpdateRequest(new_ingredient_name="대파", quantity=5),
+        )
+        service.delete_inventory_item("대파")
+        quantities = {
+            item.ingredient_name: item.quantity
+            for item in service.list_inventory().data
+        }
+
+        self.assertEqual("success", created.status)
+        self.assertEqual("마늘", created.ingredient_name)
+        self.assertEqual(3, created.current_quantity)
+        self.assertEqual("success", updated.status)
+        self.assertEqual("대파", updated.ingredient_name)
+        self.assertEqual(5, updated.current_quantity)
+        self.assertNotIn("대파", quantities)
+
+    def test_favorite_recipe_crud_preserves_recommendation_payload(self) -> None:
+        service = FavoriteRecipeService(
+            self.db,
+            FavoriteRecipeRepository(self.db),
+        )
+        payload = FavoriteRecipeCreate(
+            liquor="소주",
+            name="대파 삼겹살 볶음",
+            reason="소주와 잘 어울립니다.",
+            ingredient_yes=["대파"],
+            ingredient_no=["돼지고기"],
+            recipe=["1. 대파를 썹니다."],
+            missing_ingredients=["돼지고기"],
+            priority_rank=1,
+        )
+
+        created = service.create_favorite(payload)
+        listed = service.list_favorites()
+        detail = service.get_favorite(created.favorite_id)
+        deleted = service.delete_favorite(created.favorite_id)
+
+        self.assertEqual("success", created.status)
+        self.assertEqual(1, len(listed.data))
+        self.assertEqual(created.favorite_id, detail.data["favorite_id"])
+        self.assertEqual(1, detail.data["priority_rank"])
+        self.assertEqual(["돼지고기"], detail.data["missing_ingredients"])
+        self.assertEqual("success", deleted.status)
+
     def test_recommendation_accepts_korean_liquor_and_returns_display_safe_text(self) -> None:
         response = RecommendationService(self.db).get_recommendations("레드와인", False)
 
@@ -656,6 +737,25 @@ class ServiceQualityGateTest(unittest.TestCase):
 
         self.assertEqual(12, len(seen_names))
         self.assertGreaterEqual(len(set(seen_names)), 9)
+
+    def test_partial_refresh_keeps_selected_recommendation(self) -> None:
+        service = RecommendationService(self.db)
+        original = service.get_recommendations("소주", False)
+        kept = original.recommendations[0].model_dump(mode="json")
+
+        response = service.refresh_with_keep(
+            RecommendationRefreshRequest(
+                liquor="소주",
+                keep_recommendations=[kept],
+                refresh_count=2,
+            )
+        )
+        names = [item["name"] for item in response.recommendations]
+
+        self.assertEqual("소주", response.liquor)
+        self.assertEqual(3, len(response.recommendations))
+        self.assertEqual(kept["name"], response.recommendations[0]["name"])
+        self.assertEqual(len(names), len(set(names)))
 
     def test_all_liquor_recommendation_responses_are_display_safe(self) -> None:
         service = RecommendationService(self.db)

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -676,7 +676,8 @@ class ServiceQualityGateTest(unittest.TestCase):
 
         self.assertEqual("success", created.status)
         self.assertEqual(1, len(listed.data))
-        self.assertEqual(created.favorite_id, detail.data["favorite_id"])
+        self.assertEqual(str(created.favorite_id), detail.data["favorite_id"])
+        self.assertEqual(str(created.favorite_id), detail.data["id"])
         self.assertEqual(1, detail.data["priority_rank"])
         self.assertEqual(["돼지고기"], detail.data["missing_ingredients"])
         self.assertEqual("success", deleted.status)


### PR DESCRIPTION
Closes #26\n\n- 식재료 스캔 시작과 scan_request_id SSE 연동\n- 재고 직접 추가/수정/삭제, 즐겨찾기 레시피 API 추가\n- 고정 추천 제외 재추천 API 추가\n- 최신 FE 브랜치의 inventory 수정 payload와 favorite detail id 매핑 호환\n\nTest:\n- 34 passed\n- FE latest branch on 5173 smoke: inventory CRUD, scan start, recommendations, pinned refresh, favorite save/list/detail id/delete\n- BE local smoke: health ok