### PR TITLE
[BE] mock 스캔 자동 발행 제거

### DIFF
--- a/app/api/routes/scan.py
+++ b/app/api/routes/scan.py
@@ -17,7 +17,8 @@ router = APIRouter(prefix="/api/v1/scan", tags=["스캔 요청"])
     summary="주류 스캔 요청",
     description=(
         "홈 화면에서 주류 스캔 버튼을 누르면 백엔드가 주류 스캔 요청을 접수합니다. "
-        "현재는 FE 테스트를 위해 mock 스캔 흐름을 실행하며, 접수 후 잠시 뒤 주류 SSE와 추천 SSE를 순차적으로 발행합니다."
+        "이 API는 scan_request_id만 발급하며, 실제 인식 결과는 AI/Jetson이 "
+        "`/api/v1/recognitions/liquor`로 POST할 때 SSE로 발행됩니다."
     ),
     response_description="주류 스캔 요청 접수 결과와 scan_request_id를 반환합니다.",
 )
@@ -32,7 +33,11 @@ async def start_liquor_scan(
     "/ingredients/start",
     response_model=IngredientScanStartResponse,
     summary="식재료 스캔 요청",
-    description="홈 화면에서 식재료 스캔 버튼을 누르면 식재료 인식 mock 흐름을 시작합니다.",
+    description=(
+        "홈 화면에서 식재료 스캔 버튼을 누르면 백엔드가 식재료 스캔 요청을 접수합니다. "
+        "이 API는 scan_request_id만 발급하며, 실제 인식 결과는 AI/Jetson이 "
+        "`/api/v1/recognitions/ingredients`로 POST할 때 SSE로 발행됩니다."
+    ),
     response_description="식재료 스캔 요청 접수 결과와 scan_request_id를 반환합니다.",
 )
 async def start_ingredient_scan(

--- a/app/services/recognition_service.py
+++ b/app/services/recognition_service.py
@@ -1,6 +1,5 @@
 import asyncio
 from datetime import datetime, timezone
-from random import choice
 
 from app.db import SessionLocal
 from app.schemas.recognition import (
@@ -26,27 +25,6 @@ from app.services.name_mapping import (
     normalize_liquor_key,
 )
 from app.services.recommendation_service import RecommendationService
-
-
-MOCK_LIQUOR_SCAN_CANDIDATES: tuple[str, ...] = (
-    "soju",
-    "beer",
-    "red_wine",
-    "white_wine",
-    "sparkling_wine",
-    "whisky",
-    "sake",
-)
-
-MOCK_INGREDIENT_SCAN_CANDIDATES: tuple[str, ...] = (
-    "green_onion",
-    "onion",
-    "garlic",
-    "egg",
-    "pork",
-    "potato",
-    "mushroom",
-)
 
 
 class RecognitionService:
@@ -84,10 +62,10 @@ class RecognitionService:
     async def start_liquor_scan(
         self, payload: LiquorScanStartRequest
     ) -> LiquorScanStartResponse:
+        _ = payload
         scan_request_id = (
             f"liquor-scan-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S%f')[:-3]}"
         )
-        asyncio.create_task(self._mock_liquor_scan_flow(payload.device_id, scan_request_id))
         return LiquorScanStartResponse(
             status="accepted",
             message="주류 스캔을 시작했습니다.",
@@ -97,43 +75,15 @@ class RecognitionService:
     async def start_ingredient_scan(
         self, payload: IngredientScanStartRequest
     ) -> IngredientScanStartResponse:
+        _ = payload
         scan_request_id = (
             f"ingredient-scan-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S%f')[:-3]}"
-        )
-        asyncio.create_task(
-            self._mock_ingredient_scan_flow(payload.device_id, scan_request_id)
         )
         return IngredientScanStartResponse(
             status="accepted",
             message="식재료 스캔을 시작했습니다.",
             scan_request_id=scan_request_id,
         )
-
-    async def _mock_liquor_scan_flow(self, device_id: str, scan_request_id: str) -> None:
-        # FE가 스캔 중 상태를 잠깐 보여줄 수 있도록 약간의 지연 후
-        # mock 주류 인식 결과를 발행합니다.
-        await asyncio.sleep(3.0)
-        payload = LiquorLiveRecognitionCreate(
-            liquor_name=choice(MOCK_LIQUOR_SCAN_CANDIDATES),
-            timestamp=datetime.now(timezone.utc),
-            confidence=0.99,
-            source=f"manual_scan_mock:{device_id}",
-            scan_request_id=scan_request_id,
-        )
-        await self.publish_liquor_live_result(payload)
-
-    async def _mock_ingredient_scan_flow(
-        self, device_id: str, scan_request_id: str
-    ) -> None:
-        await asyncio.sleep(1.0)
-        payload = IngredientLiveRecognitionCreate(
-            ingredient_name=choice(MOCK_INGREDIENT_SCAN_CANDIDATES),
-            timestamp=datetime.now(timezone.utc),
-            confidence=0.98,
-            source=f"manual_scan_mock:{device_id}",
-            scan_request_id=scan_request_id,
-        )
-        await self.publish_ingredient_live_result(payload)
 
     async def _publish_recommendation_event(self, liquor_name: str) -> None:
         liquor_key = normalize_liquor_key(liquor_name)

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -29,10 +29,6 @@ from app.services.name_mapping import (
     normalize_ingredient_key,
     normalize_liquor_key,
 )
-from app.services.recognition_service import (
-    MOCK_INGREDIENT_SCAN_CANDIDATES,
-    MOCK_LIQUOR_SCAN_CANDIDATES,
-)
 from app.services.recommendation_service import RecommendationService
 
 
@@ -41,6 +37,8 @@ SEED_PATH = ROOT_DIR / "seeds" / "recommendations.json"
 POLICY_PATH = ROOT_DIR / "docs" / "recommendation_policy.md"
 README_PATH = ROOT_DIR / "README.md"
 EVENT_ROUTE_PATH = ROOT_DIR / "app" / "api" / "routes" / "events.py"
+SCAN_ROUTE_PATH = ROOT_DIR / "app" / "api" / "routes" / "scan.py"
+RECOGNITION_SERVICE_PATH = ROOT_DIR / "app" / "services" / "recognition_service.py"
 OPERATIONS_READINESS_PATH = ROOT_DIR / "docs" / "operations_readiness.md"
 DB_INIT_SCRIPT_PATH = ROOT_DIR / "scripts" / "initialize_database.py"
 FE_API_CONTRACT_PATH = ROOT_DIR / "docs" / "api_contract_fe.md"
@@ -401,19 +399,6 @@ class MappingQualityGateTest(unittest.TestCase):
         self.assertEqual("sparkling_wine", normalize_liquor_key("스파클링와인"))
         self.assertEqual("스파클링와인", liquor_display_name("sparkling_wine"))
 
-    def test_manual_scan_mock_covers_all_seed_liquors(self) -> None:
-        self.assertEqual(
-            set(EXPECTED_LIQUOR_COUNTS),
-            set(MOCK_LIQUOR_SCAN_CANDIDATES),
-        )
-        self.assertEqual(7, len(MOCK_LIQUOR_SCAN_CANDIDATES))
-
-    def test_manual_ingredient_scan_mock_uses_supported_keys(self) -> None:
-        self.assertGreaterEqual(len(MOCK_INGREDIENT_SCAN_CANDIDATES), 3)
-        self.assertTrue(
-            set(MOCK_INGREDIENT_SCAN_CANDIDATES).issubset(ALLOWED_INGREDIENT_KEYS)
-        )
-
     def test_stream_events_include_scan_request_id(self) -> None:
         ingredient_event = IngredientStreamEvent(
             ingredient_name="대파",
@@ -428,6 +413,21 @@ class MappingQualityGateTest(unittest.TestCase):
 
         self.assertEqual("ingredient-scan-001", ingredient_event.scan_request_id)
         self.assertEqual("liquor-scan-001", liquor_event.scan_request_id)
+
+    def test_scan_start_contract_has_no_mock_auto_publish_flow(self) -> None:
+        recognition_service_text = RECOGNITION_SERVICE_PATH.read_text(encoding="utf-8")
+        scan_route_text = SCAN_ROUTE_PATH.read_text(encoding="utf-8")
+
+        for forbidden in [
+            "MOCK_",
+            "_mock_",
+            "manual_scan_mock",
+            "choice(",
+        ]:
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, recognition_service_text)
+
+        self.assertNotIn("mock", scan_route_text.lower())
 
 
 class PolicyDocumentationQualityGateTest(unittest.TestCase):


### PR DESCRIPTION
## 작업\n- 스캔 시작 API의 mock 자동 SSE 발행 제거\n- 실제 AI POST만 인식 SSE를 발행하도록 정리\n- 관련 품질 게이트 갱신\n\n## 테스트\n- .venv python -m pytest -q -p no:cacheprovider